### PR TITLE
Add Google Chrome browser to browser, to enable headless unit tests.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -104,6 +104,13 @@ RUN cd /opt && curl -o- https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VE
 # Install Yarn 
 RUN cd /opt && curl -L -o- https://github.com/yarnpkg/yarn/releases/download/v${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz | tar xz
 
+# Install Google Chrome browser
+
+RUN cd /tmp && \
+    wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
+    apt install -y ./google-chrome-stable_current_amd64.deb fonts-liberation libappindicator3-1 libxss1 xdg-utils libdbusmenu-glib4 libdbusmenu-gtk3-4 libindicator3-7 && \
+    rm google-chrome-stable_current_amd64.deb
+
 # Create bashrc
 RUN mkdir /root/.m2 && \
     echo "export JAVA_HOME=${JAVA_HOME}" >> /root/.bashrc && \


### PR DESCRIPTION
Note that Google Chrome browser needs to be start up with `--no-sandbox`
